### PR TITLE
Added namespaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,32 +45,54 @@ const metrics = ioMetrics.register.metrics();
 
 ## Options
 
-| Option                    | Default       | Description                        |
-| ------------------------- | --------------| ---------------------------------- |
-| `path`                    | "/metrics"    | Metrics path                       |
-| `port`                    | 9090          | Metrics port                       |
-| `createServer`            | true          | Auto create http server            |
-| `collectDefaultMetrics`   | false         | Collect prometheus default metrics |
+| Option                    | Default       | Description                                                  |
+| ------------------------- | --------------| ------------------------------------------------------------ |
+| `path`                    | "/metrics"    | Metrics path                                                 |
+| `port`                    | 9090          | Metrics port                                                 |
+| `createServer`            | true          | Auto create http server                                      |
+| `collectDefaultMetrics`   | false         | Collect prometheus default metrics                           |
+| `checkForNewNamespaces`   | true          | Collect metrics for namespaces that will be added at runtime |
 
 ## Socket.io metrics
 
 > all metrics have `socket_io_` prefix in their names.
 
-| Name                              | Help                                         | Labels  |
-| --------------------------------- | ---------------------------------------------| ------- |
-| `socket_io_connected`             | Number of currently connected sockets        |         |
-| `socket_io_connect_total`         | Total count of socket.io connection requests |         |
-| `socket_io_disconnect_total`      | Total count of socket.io disconnections      |         |
-| `socket_io_errors_total`          | Total count of socket.io errors              |         |
-| `socket_io_events_received_total` | Total count of socket.io recieved events     | `event` |
-| `socket_io_events_sent_total`     | Total count of socket.io sent events         | `event` |
-| `socket_io_recieve_bytes`         | Total socket.io bytes recieved               | `event` |
-| `socket_io_transmit_bytes`        | Total socket.io bytes transmitted            | `event` |
+| Name                              | Help                                         | Labels               |
+| --------------------------------- | ---------------------------------------------| -------------------  |
+| `socket_io_connected`             | Number of currently connected sockets        |                      |
+| `socket_io_connect_total`         | Total count of socket.io connection requests | `namespace`          |
+| `socket_io_disconnect_total`      | Total count of socket.io disconnections      | `namespace`          |
+| `socket_io_errors_total`          | Total count of socket.io errors              | `namespace`          |
+| `socket_io_events_received_total` | Total count of socket.io recieved events     | `event`, `namespace` |
+| `socket_io_events_sent_total`     | Total count of socket.io sent events         | `event`, `namespace` |
+| `socket_io_recieve_bytes`         | Total socket.io bytes recieved               | `event`, `namespace` |
+| `socket_io_transmit_bytes`        | Total socket.io bytes transmitted            | `event`, `namespace` |
 
 ## Prometheus default metrics
 > available if `collectDefaultMetrics` is set to `true`
 
 More information [here](https://github.com/siimon/prom-client#default-metrics) and [here](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors).
+
+## Namespaces support
+
+Default namespace has label value of `'/'`.
+
+By default library checks `io.nsps` variable for new namespaces to collect metrics from. This check occurs every 2 seconds. 
+
+You can disable this functionality by providing `checkForNewNamespaces` option with `false` value.
+For example:
+
+```ts
+prometheus.metrics(io, {
+    checkForNewNamespaces: false
+});
+```
+
+With this functionality disabled, library will only collect metrics from namespaces that 
+were available at the moment of call to `prometheus.metrics(io, ...)`, 
+default namespace is included.  
+
+More information about socket.io namespaces [here](https://socket.io/docs/rooms-and-namespaces).   
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ export interface IMetricsOptions {
     path?: string;
     createServer?: boolean,
     collectDefaultMetrics?: boolean
+    checkForNewNamespaces?: boolean
 }
 
 export interface IMetrics {
@@ -35,11 +36,14 @@ export class SocketIOMetrics {
 
     private options: IMetricsOptions;
 
+    private boundNamespaces = new Set();
+
     private defaultOptions: IMetricsOptions = {
         port: 9090,
         path: '/metrics',
         createServer: true,
-        collectDefaultMetrics: false
+        collectDefaultMetrics: false,
+        checkForNewNamespaces: true
     };
 
     constructor(ioServer: io.Server, options?: IMetricsOptions) {
@@ -81,7 +85,7 @@ export class SocketIOMetrics {
         this.express.get(this.options.path, (req: express.Request, res: express.Response) => {
             const engine: any = this.ioServer.engine;
             this.metrics.connectedSockets.set(engine.clientsCount);
-            
+
             res.set('Content-Type', this.register.contentType);
             res.end(this.register.metrics());
         });
@@ -100,46 +104,49 @@ export class SocketIOMetrics {
 
             connectTotal: new prom.Counter({
                 name: 'socket_io_connect_total',
-                help: 'Total count of socket.io connection requests'
+                help: 'Total count of socket.io connection requests',
+                labelNames: ['namespace']
             }),
 
             disconnectTotal: new prom.Counter({
                 name: 'socket_io_disconnect_total',
-                help: 'Total count of socket.io disconnections'
+                help: 'Total count of socket.io disconnections',
+                labelNames: ['namespace']
             }),
 
             eventsReceivedTotal: new prom.Counter({
                 name: 'socket_io_events_received_total',
                 help: 'Total count of socket.io recieved events',
-                labelNames: ['event']
+                labelNames: ['event', 'namespace']
             }),
 
             eventsSentTotal: new prom.Counter({
                 name: 'socket_io_events_sent_total',
                 help: 'Total count of socket.io sent events',
-                labelNames: ['event']
+                labelNames: ['event', 'namespace']
             }),
 
             bytesReceived: new prom.Counter({
                 name: 'socket_io_recieve_bytes',
                 help: 'Total socket.io bytes recieved',
-                labelNames: ['event']
+                labelNames: ['event', 'namespace']
             }),
 
             bytesTransmitted: new prom.Counter({
                 name: 'socket_io_transmit_bytes',
                 help: 'Total socket.io bytes transmitted',
-                labelNames: ['event']
+                labelNames: ['event', 'namespace']
             }),
 
             errorsTotal: new prom.Counter({
                 name: 'socket_io_errors_total',
-                help: 'Total socket.io errors'
+                help: 'Total socket.io errors',
+                labelNames: ['namespace']
             })
         };
     }
 
-    private bindMetrics() {
+    private bindMetricsOnEmitter(server: NodeJS.EventEmitter, labels: prom.labelValues) {
         const blacklisted_events = new Set([
             'error',
             'connect',
@@ -149,21 +156,22 @@ export class SocketIOMetrics {
             'removeListener'
         ]);
 
-        this.ioServer.on('connect', (socket: any) => {
+        server.on('connect', (socket: any) => {
             // Connect events
-            this.metrics.connectTotal.inc();
+            this.metrics.connectTotal.inc(labels);
 
             // Disconnect events
             socket.on('disconnect', () => {
-                this.metrics.disconnectTotal.inc();
+                this.metrics.disconnectTotal.inc(labels);
             });
 
             // Hook into emit (outgoing event)
             const org_emit = socket.emit;
             socket.emit = (event: string, ...data: any[]) => {
                 if (!blacklisted_events.has(event)) {
-                    this.metrics.bytesTransmitted.labels(event).inc(this.dataToBytes(data));
-                    this.metrics.eventsSentTotal.labels(event).inc();
+                    let labelsWithEvent = { event: event, ...labels };
+                    this.metrics.bytesTransmitted.inc(labelsWithEvent, this.dataToBytes(data));
+                    this.metrics.eventsSentTotal.inc(labelsWithEvent);
                 }
 
                 return org_emit.apply(socket, [event, ...data]);
@@ -176,16 +184,40 @@ export class SocketIOMetrics {
                     const [event, data] = packet.data;
 
                     if (event === 'error') {
-                        this.metrics.errorsTotal.inc();
+                        this.metrics.errorsTotal.inc(labels);
                     } else if (!blacklisted_events.has(event)) {
-                        this.metrics.bytesReceived.labels(event).inc(this.dataToBytes(data));
-                        this.metrics.eventsReceivedTotal.labels(event).inc();
+                        let labelsWithEvent = { event: event, ...labels };
+                        this.metrics.bytesReceived.inc(labelsWithEvent, this.dataToBytes(data));
+                        this.metrics.eventsReceivedTotal.inc(labelsWithEvent);
                     }
                 }
 
                 return org_onevent.call(socket, packet);
             };
         });
+    }
+
+    private bindNamespaceMetrics(server: io.Server, namespace: string) {
+        if (this.boundNamespaces.has(namespace)) {
+            return;
+        }
+        const namespaceServer = server.of(namespace);
+        this.bindMetricsOnEmitter(namespaceServer, { namespace: namespace });
+        this.boundNamespaces.add(namespace);
+    }
+
+    private bindMetrics() {
+        Object.keys(this.ioServer.nsps).forEach((nsp) =>
+            this.bindNamespaceMetrics(this.ioServer, nsp)
+        );
+
+        if (this.options.checkForNewNamespaces) {
+            setInterval(() => {
+                Object.keys(this.ioServer.nsps).forEach((nsp) =>
+                    this.bindNamespaceMetrics(this.ioServer, nsp)
+                );
+            }, 2000);
+        }
     }
 
     /*


### PR DESCRIPTION
Fixing lack of support for namespaces in socket.io-prometheus-metrics.
Before only events from default namespaces were tracked.