### PR TITLE
socket_io_connected is always 0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -159,10 +159,12 @@ export class SocketIOMetrics {
         server.on('connect', (socket: any) => {
             // Connect events
             this.metrics.connectTotal.inc(labels);
+            this.metrics.connectedSockets.set(this.ioServer.engine.clientsCount);
 
             // Disconnect events
             socket.on('disconnect', () => {
                 this.metrics.disconnectTotal.inc(labels);
+                this.metrics.connectedSockets.set(this.ioServer.engine.clientsCount);
             });
 
             // Hook into emit (outgoing event)


### PR DESCRIPTION
updates socket_io_connected when new socket connected or disconnected
sample and simple fix for https://github.com/UNIwise/socket.io-prometheus-metrics/issues/5